### PR TITLE
Explorer les possibles pour ne pas les regretter

### DIFF
--- a/musee-mariani/README.md
+++ b/musee-mariani/README.md
@@ -3,7 +3,7 @@ canonical_url: https://github.com/JeanHuguesRobert/barons-Mariani/blob/main/muse
 author: "Jean Hugues Noël Robert, baron Mariani"
 affiliation: "Institut Mariani / C.O.R.S.I.C.A., 1 cours Paoli, F-20250 Corte, Corsica"
 license: "CC BY-SA 4.0"
-last_stamped_at: 2026-06-26
+last_stamped_at: 2026-07-08
 title: "Musée Mariani — préfiguration"
 date: "2026-06-26"
 status: "draft"
@@ -62,6 +62,7 @@ musee-mariani/
     indice_capacite_retrouvee.md
     grille_remise_en_service.md
     articulation_musee_uchronique.md
+    exploration_rationnelle_des_possibles.md
   juridique/
     demander_au_juge.md
     autorisations_ateliers_sous_traites.md
@@ -95,6 +96,7 @@ La doctrine est accompagnée d'une première série de documents opérationnels 
 - [`methodes/indice_capacite_retrouvee.md`](methodes/indice_capacite_retrouvee.md) — mesure de ce qu'un atelier rend possible.
 - [`methodes/grille_remise_en_service.md`](methodes/grille_remise_en_service.md) — diagnostic du composant d'accès manquant.
 - [`methodes/articulation_musee_uchronique.md`](methodes/articulation_musee_uchronique.md) — articulation avec le Musée uchronique.
+- [`methodes/exploration_rationnelle_des_possibles.md`](methodes/exploration_rationnelle_des_possibles.md) — méthode générale : explorer les possibles pour éviter que le présent ne devienne une uchronie future.
 
 **Juridique**
 
@@ -118,6 +120,8 @@ Le document source actuellement le plus avancé reste :
 - [`research/uchronian_museum.md`](../research/uchronian_museum.md) — *Le Musée uchronique comme dispositif d’inférence historique appliqué aux territoires insulaires*.
 
 Le présent sous-corpus ne remplace pas ce document. Il en prépare la déclinaison muséale concrète : cartels, dossiers, parcours, collections, vérifications et médiation publique.
+
+Le document [`methodes/exploration_rationnelle_des_possibles.md`](methodes/exploration_rationnelle_des_possibles.md) précise le pont méthodologique : l'uchronie n'est pas seulement une fiction du passé, mais une méthode de vigilance permettant d'éviter que les possibles du présent ne deviennent les regrets d'une uchronie future.
 
 ## Règle d'Occam
 

--- a/musee-mariani/methodes/articulation_musee_uchronique.md
+++ b/musee-mariani/methodes/articulation_musee_uchronique.md
@@ -14,6 +14,7 @@ visibility: "public"
 lifecycle_state: "working"
 related_documents:
   - "musee-mariani/doctrine_musee_mariani_des_possibles.md"
+  - "musee-mariani/methodes/exploration_rationnelle_des_possibles.md"
   - "musee-mariani/notes-critiques/preuves-et-incertitudes.md"
   - "research/uchronian_museum.md"
 ---
@@ -25,6 +26,8 @@ related_documents:
 > **Statut.** Première version (v0.1). Note d'articulation entre deux dispositifs muséaux du même domaine.
 
 Le Musée des Possibles a un concept compagnon : le Musée uchronique, dispositif d'inférence historique fondé sur l'histoire contrefactuelle appliquée à un territoire (§28). Les deux ne s'opposent pas ; ils explorent le même espace de possibilités selon deux axes de temps. Cette note précise leur articulation et la discipline commune qui les protège tous deux de la fiction non maîtrisée.
+
+Le document [`exploration_rationnelle_des_possibles.md`](exploration_rationnelle_des_possibles.md) généralise cette articulation : l'uchronie y devient une méthode de vigilance destinée à éviter que le présent ne produise les regrets d'une uchronie future.
 
 ## Deux axes, un même espace
 

--- a/musee-mariani/methodes/exploration_rationnelle_des_possibles.md
+++ b/musee-mariani/methodes/exploration_rationnelle_des_possibles.md
@@ -1,0 +1,258 @@
+---
+canonical_url: https://github.com/JeanHuguesRobert/barons-Mariani/blob/main/musee-mariani/methodes/exploration_rationnelle_des_possibles.md
+author: "Jean Hugues Noël Robert, baron Mariani"
+affiliation: "Institut Mariani / C.O.R.S.I.C.A., 1 cours Paoli, F-20250 Corte, Corsica"
+license: "CC BY-SA 4.0"
+title: "Explorer les possibles pour ne pas les regretter"
+subtitle: "Uchronie, Musée des Possibles et méthode rationnelle contre les futurs manqués"
+date: "2026-07-08"
+status: "draft"
+document_role: "method"
+document_kind: "methodological-bridge"
+visibility: "public"
+lifecycle_state: "working"
+related_documents:
+  - "musee-mariani/doctrine_musee_mariani_des_possibles.md"
+  - "musee-mariani/methodes/articulation_musee_uchronique.md"
+  - "research/uchronian_museum.md"
+  - "musee-mariani/notes-critiques/preuves-et-incertitudes.md"
+  - "research/logique_capacitaire_jhr_forth_linkos_fractanet.md"
+  - "agents-jhn/README.md"
+tags:
+  - musee-des-possibles
+  - uchronie
+  - exploration-rationnelle
+  - possibilisme
+  - capacitaire
+  - futurs-manques
+---
+
+# Explorer les possibles pour ne pas les regretter
+
+## Uchronie, Musée des Possibles et méthode rationnelle contre les futurs manqués
+
+## 1. Statut du document
+
+Ce document relie trois lignes déjà présentes dans le corpus :
+
+1. le **Musée uchronique**, qui explore les passés non advenus par des fictions contraintes ;
+2. le **Musée Mariani des Possibles**, qui documente les conditions du possible ;
+3. l'**exploration rationnelle des possibles**, comprise comme méthode générale pour mieux agir dans le présent.
+
+Il ne s'agit pas d'un texte autobiographique, même si des matériaux autobiographiques peuvent parfois servir de cas d'école. Il ne s'agit pas non plus d'une fiction libre. Le présent document propose une méthode : examiner les possibles accessibles mais non réalisés, afin d'éviter que le présent ne devienne demain une uchronie de plus.
+
+## 2. Thèse
+
+L'exploration rationnelle des possibles n'est pas un jeu intellectuel. C'est une méthode de responsabilité.
+
+Elle permet d'identifier, dans toute situation, les capacités latentes qui pourraient être composées, afin d'éviter que le présent ne devienne demain une uchronie de plus.
+
+Formule courte :
+
+> Explorer rationnellement les possibles du passé sert à apprendre à mieux explorer les possibles du présent.
+
+Formule forte :
+
+> Une uchronie bien conduite n'est pas tournée vers le passé ; elle est un instrument de responsabilité envers le futur.
+
+## 3. Pourquoi l'uchronie ne suffit pas
+
+L'uchronie demande :
+
+> que se serait-il passé si l'histoire avait bifurqué ?
+
+Cette question est utile, mais insuffisante si elle demeure narrative. Elle peut produire de la nostalgie, du regret, de la distraction ou une revendication de priorité. Ce n'est pas l'objectif ici.
+
+L'uchronie devient utile lorsqu'elle est contrainte par une discipline de preuve et par une finalité heuristique. Elle doit alors demander :
+
+- quelles briques existaient déjà ?
+- quelles combinaisons étaient plausibles ?
+- quels récits auraient pu les rendre lisibles ?
+- quelles institutions auraient pu les porter ?
+- quels blocages les ont rendues invisibles ?
+- quelles erreurs de perception ont empêché leur valorisation ?
+- quelles leçons devons-nous en tirer pour le présent ?
+
+Le but n'est donc pas de refaire mentalement le passé. Le but est de mieux lire le présent.
+
+## 4. Le Musée uchronique
+
+Le Musée uchronique explore les **passés non advenus**.
+
+Il repère un point de bifurcation, construit un scénario contrefactuel soumis à des contraintes de cohérence, compare la trajectoire advenue à celle qui ne l'a pas été, puis cherche ce que cette comparaison révèle du présent.
+
+Son enjeu n'est pas de divertir par l'imaginaire. Il est d'utiliser la fiction contrainte comme un opérateur d'inférence historique.
+
+Le Musée uchronique demande :
+
+```text
+qu'est-ce qui aurait pu être possible
+si l'histoire avait bifurqué ?
+```
+
+## 5. Le Musée des Possibles
+
+Le Musée Mariani des Possibles explore les **présents empêchés** et les **futurs praticables**.
+
+Il ne conserve pas seulement des traces. Il cherche à comprendre les conditions qui ont rendu certaines pratiques possibles, difficiles, interdites, oubliées, transmissibles ou réactivables.
+
+Il demande :
+
+```text
+qu'est-ce qui pourrait redevenir possible
+si l'on levait tel empêchement ?
+```
+
+Un objet muséal n'est donc pas seulement un vestige. Il est une preuve de possibilité. Un pressoir, un moulin, un alambic, une vigne, une source, une maison ou une institution attestent qu'une certaine forme de vie a tenu, au moins pendant un temps.
+
+Le Musée des Possibles transforme cette trace en enquête :
+
+```text
+ce qui fut possible
+→ pourquoi cela le fut
+→ pourquoi cela ne l'est plus
+→ à quelles conditions cela pourrait le redevenir
+```
+
+## 6. Méthode commune
+
+Le Musée uchronique et le Musée des Possibles ne sont pas deux projets séparés. Ils explorent le même espace selon deux axes temporels.
+
+```text
+Musée uchronique
+→ passés non advenus
+→ bifurcations historiques
+→ fiction contrainte
+
+Musée des Possibles
+→ présents empêchés
+→ futurs praticables
+→ capacités à réactiver
+```
+
+La méthode commune est l'exploration rationnelle des possibles.
+
+Elle impose trois exigences :
+
+1. **continuité causale** : ne pas supposer n'importe quoi ;
+2. **cohérence interne** : ne pas juxtaposer des hypothèses arbitraires ;
+3. **utilité heuristique** : produire une connaissance utile au présent.
+
+Ces exigences protègent le corpus contre la fiction non maîtrisée.
+
+## 7. Éviter les futurs manqués
+
+Chaque époque contient des possibles qu'elle ne sait pas voir.
+
+Certaines briques existent déjà. Certaines pratiques émergent. Certains prototypes apparaissent. Certains savoirs sont disponibles. Certains récits pourraient les relier. Pourtant, faute de méthode, de courage, d'institution ou de langage commun, ces possibles peuvent rester dispersés jusqu'à devenir, plus tard, les objets d'une uchronie.
+
+Le Musée des Possibles doit précisément empêcher cela.
+
+Il expose les futurs manqués non pour cultiver la nostalgie, mais pour apprendre à ne pas manquer les futurs présents.
+
+La question n'est donc pas seulement :
+
+> que serait-il arrivé si le passé avait été différent ?
+
+La question décisive est :
+
+> que devons-nous mieux explorer aujourd'hui pour que demain ne puisse pas écrire l'uchronie de notre aveuglement ?
+
+## 8. Application au présent de 2026
+
+Le présent de 2026 contient lui aussi des possibles mal reconnus.
+
+Certains ne demandent pas une invention radicale, mais une meilleure composition des ressources existantes :
+
+- énergie locale ;
+- calcul distribué ;
+- agents logiciels ;
+- corpus versionnés ;
+- mandats numériques ;
+- cryptographie ;
+- réseaux sobres ;
+- institutions ouvertes ;
+- formes nouvelles de coopération.
+
+Si ces possibles ne sont pas explorés maintenant, une uchronie future pourra être écrite dans vingt ou trente ans. Elle dira peut-être :
+
+> que serait devenue la Corse, l'Europe, ou le numérique public, si en 2026 nous avions su mieux utiliser l'IA, l'énergie locale, les agents, les communs numériques et les infrastructures ouvertes ?
+
+L'enjeu est précisément d'éviter cela.
+
+## 9. Rapport à l'autobiographie technique
+
+Les informations autobiographiques peuvent avoir leur place dans cette méthode, mais elles ne doivent pas en devenir le centre.
+
+Elles servent de **preuves locales de plausibilité** : elles montrent que certains possibles n'étaient pas seulement abstraits. Ils existaient déjà sous forme de gestes techniques, de prototypes, de langages, de noyaux, de passerelles, de produits partiels ou d'expériences industrielles.
+
+Le matériau autobiographique ne doit donc pas être utilisé pour dire :
+
+```text
+j'aurais pu inventer ce futur
+```
+
+Il doit plutôt servir à montrer :
+
+```text
+certaines briques de ce futur étaient déjà praticables
+mais elles n'ont pas été composées en infrastructure durable
+```
+
+Cette distinction est essentielle.
+
+## 10. Rapport à la logique capacitaire
+
+L'exploration rationnelle des possibles rejoint directement la logique capacitaire.
+
+Il ne s'agit pas seulement d'imaginer. Il s'agit de rendre capable.
+
+```text
+possible repéré
+→ empêchement identifié
+→ conditions de réactivation décrites
+→ capacité reconstruite
+→ preuve conservée
+→ transmission organisée
+```
+
+Le Musée des Possibles n'est donc pas un musée de l'imaginaire. C'est une institution de vigilance capacitaire.
+
+Il expose les bifurcations, les impasses et les capacités dormantes pour augmenter la capacité présente d'une société à comprendre, décider et agir.
+
+## 11. Rapport aux Agents JHN
+
+Les Agents JHN peuvent contribuer à cette méthode sous mandat : clarifier, auditer, archiver, produire des cartes, préparer des publications, maintenir les distinctions de preuve et proposer des reprises.
+
+Ils ne doivent pas inventer des possibles. Ils doivent aider à les instruire.
+
+Leur rôle est donc auxiliaire :
+
+```text
+source
+→ clarification
+→ audit
+→ statut de preuve
+→ hypothèse contrainte
+→ fiche de possible
+→ décision humaine
+```
+
+Les Agents JHN ne remplacent pas l'enquête humaine. Ils augmentent sa capacité de mémoire, de structuration, de contradiction et de transmission.
+
+## 12. Formule canonique
+
+> L'exploration rationnelle des possibles consiste à identifier, dans toute situation, les capacités latentes qui pourraient être composées, afin d'éviter que le présent ne devienne demain une uchronie de plus.
+
+## 13. Usage dans le corpus
+
+Ce document doit servir de pont entre :
+
+- la doctrine du Musée Mariani des Possibles ;
+- l'articulation avec le Musée uchronique ;
+- les textes d'uchronie contrainte ;
+- la logique capacitaire ;
+- les Agents JHN ;
+- les futures fiches de possibles.
+
+Il doit également guider les futurs textes uchroniques : tout scénario contrefactuel doit expliciter ce qu'il apprend au présent, et toute fiche de possible doit indiquer quel regret futur elle cherche à éviter.

--- a/research/uchronian_museum.md
+++ b/research/uchronian_museum.md
@@ -3,7 +3,7 @@ canonical_url: https://github.com/JeanHuguesRobert/barons-Mariani/blob/main/rese
 author: "Jean Hugues Noël Robert, baron Mariani"
 affiliation: "Institut Mariani / C.O.R.S.I.C.A., 1 cours Paoli, F-20250 Corte, Corsica"
 license: "CC BY-SA 4.0"
-last_stamped_at: 2026-06-01
+last_stamped_at: 2026-07-08
 title: "Le Musée uchronique comme dispositif d’inférence historique appliqué aux territoires insulaires"
 date: "2026-04-06"
 status: "draft — auto-filled (frontmatter cleanup)"
@@ -137,6 +137,14 @@ Le Musée uchronique constitue une proposition de renouvellement des pratiques m
 L’étude de cas napoléonienne en Corse illustre la capacité de ce dispositif à produire des modèles analytiques alternatifs des dynamiques territoriales.
 
 Il s’agit moins de réécrire l’histoire que de la transformer en espace de simulation structurée.
+
+---
+
+### 9. Prolongement méthodologique
+
+Le document [`../musee-mariani/methodes/exploration_rationnelle_des_possibles.md`](../musee-mariani/methodes/exploration_rationnelle_des_possibles.md) prolonge cette thèse vers une méthode plus générale : explorer rationnellement les possibles afin d'éviter que le présent ne devienne, demain, l'objet d'une uchronie du regret.
+
+Le Musée uchronique y apparaît comme un cas particulier d'une discipline plus large : l'exploration rationnelle des possibles en toutes circonstances.
 
 ---
 


### PR DESCRIPTION
## Objet

Ajoute un document pivot reliant :

- le Musée uchronique ;
- le Musée Mariani des Possibles ;
- l'exploration rationnelle des possibles ;
- la logique capacitaire ;
- les Agents JHN.

## Nouveau document

- `musee-mariani/methodes/exploration_rationnelle_des_possibles.md`

Thèse centrale :

> L'exploration rationnelle des possibles consiste à identifier, dans toute situation, les capacités latentes qui pourraient être composées, afin d'éviter que le présent ne devienne demain une uchronie de plus.

## Liens internes ajoutés

- `musee-mariani/README.md`
- `musee-mariani/methodes/articulation_musee_uchronique.md`
- `research/uchronian_museum.md`

## Hors périmètre

- Pas de mise à jour automatique des index générés.
- Pas de liens croisés multi-dépôts.
- Pas de fusion directe : PR à relire.