### PR TITLE
Documenter la transition possibiliste et la protection des lanceurs d’alerte

### DIFF
--- a/research/protection_des_lanceurs_d_alerte.md
+++ b/research/protection_des_lanceurs_d_alerte.md
@@ -1,0 +1,294 @@
+---
+title: "Protéger les lanceurs d'alerte"
+subtitle: "De la réception de l'information à la préservation durable de la capacité d'agir"
+author: "Jean Hugues Noël Robert"
+affiliation: "Institut Mariani / C.O.R.S.I.C.A., 1 cours Paoli, F-20250 Corte, Corsica"
+date: "2026-07-20"
+version: "0.1"
+status: "working-note — reconstruction doctrinale à soumettre à recherche juridique"
+license: "CC BY-SA 4.0"
+canonical_url: "https://github.com/JeanHuguesRobert/barons-Mariani/blob/main/research/protection_des_lanceurs_d_alerte.md"
+document_role: "source"
+document_kind: "working-note"
+visibility: "public"
+lifecycle_state: "working"
+epistemic_status: "reconstruction de propositions antérieures ; état du droit non vérifié dans cette version"
+related_documents:
+  - "research/traceabilite_des_actes.md"
+  - "research/pathologie_du_secret.md"
+  - "research/transition_possibiliste_vers_une_democratie_augmentee.md"
+  - "research/impunite_par_obscurite_cas_corse_v0.2.md"
+---
+
+# Protéger les lanceurs d'alerte
+
+## Statut prudent
+
+Ce document reconstruit une doctrine développée au fil de travaux et conversations antérieurs. Il ne décrit pas de manière exhaustive l'état du droit français ou européen au 20 juillet 2026. Les références juridiques, procédures, autorités compétentes et protections effectivement opposables devront faire l'objet d'une recherche dédiée avant toute utilisation comme guide pratique.
+
+Sa fonction est de conserver le problème, les exigences et les mécanismes à étudier afin que la continuation ne reparte pas de zéro.
+
+---
+
+## 1. Le problème n'est pas seulement de recevoir l'alerte
+
+De nombreux dispositifs proposent un formulaire, une adresse ou un canal sécurisé. Cela ne suffit pas.
+
+Un lanceur d'alerte peut perdre son emploi, ses revenus, sa réputation, son logement, sa sécurité, sa santé et sa capacité de défense. Il peut être entraîné dans des procédures longues, coûteuses et asymétriques : expertises, appels, cassation, déplacements et besoins de protection.
+
+La puissance de l'organisation mise en cause peut lui permettre de fragmenter les responsabilités, retarder les procédures, isoler la personne, acheter des conseils spécialisés et transformer le coût de la vérité en sanction privée.
+
+La thèse est :
+
+> **Protéger une alerte ne consiste pas seulement à recevoir une information. Il faut préserver simultanément la preuve, la personne, sa capacité de défense et la possibilité que l'acte dénoncé soit effectivement contesté.**
+
+---
+
+## 2. Les quatre protections indissociables
+
+### 2.1. Protection informationnelle
+
+Elle concerne :
+
+- la confidentialité ou le pseudonymat lorsque nécessaires ;
+- l'intégrité et l'horodatage des pièces ;
+- la séparation entre identité, contenu et publication ;
+- la conservation de copies indépendantes ;
+- la traçabilité des accès et transformations ;
+- la possibilité de publier progressivement ;
+- la protection contre la suppression ou l'altération des preuves.
+
+L'anonymat absolu ne peut pas être promis. Toute architecture doit rendre visibles ses limites, ses métadonnées résiduelles, ses points de corrélation et les acteurs susceptibles d'être contraints de divulguer des informations.
+
+### 2.2. Protection juridique
+
+Elle ne se réduit pas à une consultation initiale. Elle peut exiger :
+
+- conseil préalable à la divulgation ;
+- qualification du statut du lanceur d'alerte ;
+- défense dans plusieurs procédures ;
+- expertises techniques, financières ou médicales ;
+- appels, cassation et recours européens éventuels ;
+- contestation des mesures de représailles ;
+- réparation des préjudices ;
+- prise en charge des déplacements et frais connexes.
+
+Une protection qui disparaît après la première démarche abandonne la personne au moment où l'asymétrie devient la plus forte.
+
+### 2.3. Protection matérielle et personnelle
+
+La personne doit pouvoir continuer à vivre et se défendre. Selon le risque, cela peut comprendre :
+
+- ressources temporaires ;
+- fonds de défense ;
+- soutien au logement ou aux déplacements ;
+- protection de la santé ;
+- sécurité physique ;
+- soutien relationnel et lutte contre l'isolement ;
+- accompagnement administratif ;
+- maintien d'une capacité de travail et de communication.
+
+La dépendance économique envers l'organisation dénoncée constitue une vulnérabilité politique. La protection doit restaurer une capacité indépendante, pas seulement offrir une reconnaissance symbolique.
+
+### 2.4. Protection institutionnelle
+
+L'organisation mise en cause ne doit pas contrôler seule :
+
+- le canal de réception ;
+- la qualification de l'alerte ;
+- les preuves ;
+- le calendrier ;
+- l'enquête ;
+- la décision de publication ;
+- la réparation ;
+- l'évaluation de ses propres représailles.
+
+La pluralité des destinataires, la réplication des preuves, les voies de recours et la publicité progressive limitent la capture.
+
+---
+
+## 3. Transparence et confidentialité
+
+La confidentialité protège parfois le lanceur d'alerte et l'intégrité de l'enquête. Elle peut aussi devenir un moyen d'ensevelir l'alerte.
+
+Le principe proposé est :
+
+> **La publicité est la destination normale ; la non-divulgation est une mesure exceptionnelle, motivée, proportionnée, traçable et bornée dans le temps.**
+
+Lorsqu'une information ne peut être immédiatement publiée, le dispositif devrait au minimum conserver :
+
+- l'existence de l'alerte ;
+- la date ;
+- le destinataire ;
+- le motif de la rétention ;
+- le fondement juridique invoqué ;
+- l'échéance de réexamen ;
+- la personne ou institution responsable ;
+- la voie de contestation ;
+- la trace des consultations et décisions.
+
+Le secret ne doit pas faire disparaître la responsabilité de celui qui décide de garder le secret.
+
+---
+
+## 4. Le secret des affaires et l'intérêt public
+
+Le secret des affaires peut protéger des intérêts économiques légitimes. Il peut aussi être invoqué pour rendre plus difficile la démonstration d'une fraude, d'un conflit d'intérêts, d'un risque collectif ou d'une chaîne de responsabilité.
+
+Ce document adopte une position critique : une protection économique ne devrait pas offrir une prime au vice ni neutraliser l'intérêt public à connaître les actes qui affectent la collectivité.
+
+Lorsque les documents internes restent inaccessibles, l'enquête à partir de données publiques peut réduire l'asymétrie : registres, marchés, décisions, participations, bénéficiaires effectifs, chronologies, actes administratifs, décisions judiciaires, déclarations, données techniques et traces numériques.
+
+---
+
+## 5. OSINT et chaînes probables de responsabilité
+
+L'OSINT ne produit pas automatiquement une preuve judiciaire ni une vérité définitive. Il peut construire une hypothèse contrôlable et rendre les incohérences visibles.
+
+Chaque élément devrait recevoir une qualification :
+
+```text
+fait vérifié
+document source
+indice
+inférence
+hypothèse de responsabilité
+allégation d'un tiers
+contradiction reçue
+fait réfuté
+qualification juridique éventuelle
+```
+
+Une chaîne probable de responsabilité devrait indiquer :
+
+- les acteurs physiques et moraux ;
+- leurs rôles et mandats connus ;
+- les actes observables ;
+- les liens capitalistiques, contractuels ou hiérarchiques ;
+- les bénéficiaires identifiables ;
+- les lacunes de preuve ;
+- les hypothèses alternatives ;
+- les personnes susceptibles de répondre ou contredire ;
+- les conséquences attendues d'une erreur d'attribution.
+
+L'objectif est de rendre le crime et l'abus plus difficiles, non de remplacer le juge par une inférence automatisée.
+
+---
+
+## 6. Du citoyen lecteur au citoyen capable d'agir
+
+La transparence reste insuffisante si le citoyen peut seulement contempler une irrégularité.
+
+Le dispositif devrait faciliter :
+
+- l'accès aux sources publiques ;
+- la production d'une objection structurée ;
+- la demande de rectification ;
+- la saisine d'une autorité compétente ;
+- la mutualisation d'une défense ;
+- l'identification des personnes ayant qualité et intérêt à agir ;
+- lorsque le droit le permet, l'action en justice ;
+- la documentation des refus, silences et délais.
+
+L'impossibilité fréquente d'ester en justice sur une question d'intérêt public constitue une limite majeure de la capacité citoyenne. Une continuation juridique devra étudier les voies existantes, les associations habilitées, l'intérêt à agir, les actions de groupe et les réformes envisageables.
+
+Formules :
+
+> **Sans trace, impunité.**
+
+> **Sans recours, la trace reste contemplative.**
+
+---
+
+## 7. Architecture minimale d'une alerte protégée
+
+```yaml
+protected_alert:
+  id: "alert-..."
+  received_at: "..."
+  reporter:
+    identity_mode: "identified | pseudonymous | anonymous"
+    identity_holder: "reporter | lawyer | trusted-third-party | none"
+    known_exposure_risks: []
+  mandate:
+    recipient: "..."
+    purpose: "assessment | preservation | investigation | publication | legal-action"
+    limits: []
+  evidence:
+    items: []
+    hashes: []
+    originals_location: "protected"
+    provenance_status: "verified | partial | unknown"
+  claims:
+    verified_facts: []
+    indications: []
+    inferences: []
+    allegations: []
+    alternative_hypotheses: []
+  protection:
+    legal: []
+    financial: []
+    personal_security: []
+    health_and_social: []
+  disclosure:
+    current_level: "private | restricted | minimal-public-trace | documented-public | full-publication"
+    withholding_reason: "..."
+    review_at: "..."
+    publication_trigger: "..."
+  accountability:
+    case_responsible: "..."
+    independent_review: "..."
+    objection_path: "..."
+    escalation_path: "..."
+  status: "received | preserved | assessed | investigated | contested | published | litigated | closed"
+```
+
+Ce schéma est exploratoire. Il ne constitue ni un outil sécurisé ni un protocole juridique validé.
+
+---
+
+## 8. Failure modes
+
+| Failure mode | Effet |
+|---|---|
+| Faux anonymat | La personne se croit protégée alors que les métadonnées l'identifient |
+| Canal capturé | L'organisation dénoncée reçoit et enterre l'alerte |
+| Preuve orpheline | Les documents circulent sans provenance ni intégrité démontrable |
+| Défense à durée courte | Le soutien s'arrête avant les procédures longues |
+| Épuisement économique | La personne renonce faute de ressources |
+| Secret sans échéance | La confidentialité devient enterrement institutionnel |
+| Publication imprudente | La personne ou des tiers sont exposés inutilement |
+| Inférence transformée en fait | Une hypothèse OSINT devient accusation non corrigible |
+| Responsabilité diffuse | Tout le monde traite le dossier, personne n'en répond |
+| Réparation symbolique | Le statut est reconnu sans restaurer la capacité perdue |
+
+---
+
+## 9. Programme de recherche et d'implémentation
+
+La prochaine version devra :
+
+1. établir l'état du droit français, européen et conventionnel ;
+2. identifier les dispositifs existants et leurs limites réelles ;
+3. distinguer les protections selon salariés, agents publics, cocontractants, citoyens et associations ;
+4. étudier les mécanismes de financement indépendant et de défense longue ;
+5. définir un modèle de publication progressive ;
+6. concevoir un profil COP/Archia pour les alertes et contre-événements ;
+7. produire un threat model technique ;
+8. soumettre le document à des avocats, journalistes d'investigation, associations et anciens lanceurs d'alerte ;
+9. tester le dispositif sur des cas historiques sans exposer de nouvelles personnes.
+
+---
+
+## Conclusion
+
+Une société capable de recevoir une vérité mais incapable de protéger celui qui la rend dicible organise indirectement le silence.
+
+La protection du lanceur d'alerte doit être conçue comme une continuité de capacité : capacité de conserver la preuve, de vivre, de se défendre, de contester, de corriger et de transmettre.
+
+---
+
+## Continuation
+
+Ce document doit rester en version de travail tant que la recherche juridique et la revue par des praticiens n'ont pas été réalisées. Toute future version doit distinguer clairement : doctrine proposée, droit positif vérifié, outils existants, hypothèses techniques et mécanismes encore inexistants.
+

--- a/research/transition_possibiliste_vers_une_democratie_augmentee.md
+++ b/research/transition_possibiliste_vers_une_democratie_augmentee.md
@@ -1,0 +1,287 @@
+---
+title: "Espérer sans promettre"
+subtitle: "Minimiser la casse pendant la transition vers une démocratie augmentée"
+author: "Jean Hugues Noël Robert"
+affiliation: "Institut Mariani / C.O.R.S.I.C.A., 1 cours Paoli, F-20250 Corte, Corsica"
+date: "2026-07-20"
+version: "0.1"
+status: "working-paper — document source issu d'une conversation de consolidation"
+license: "CC BY-SA 4.0"
+canonical_url: "https://github.com/JeanHuguesRobert/barons-Mariani/blob/main/research/transition_possibiliste_vers_une_democratie_augmentee.md"
+document_role: "source"
+document_kind: "research-paper"
+visibility: "public"
+lifecycle_state: "working"
+x_method:
+  - "seconde méthode"
+  - "possibilisme"
+  - "DHITL"
+  - "document autoporteur"
+related_documents:
+  - "research/democratic_ai_safety.md"
+  - "research/noyau_doctrinal_rendre_capable.md"
+  - "research/traceabilite_des_actes.md"
+  - "https://github.com/JeanHuguesRobert/marenostrum/blob/main/research/DHITL.md"
+  - "https://github.com/JeanHuguesRobert/marenostrum/blob/main/research/DHITL-COVENANT.md"
+  - "https://github.com/JeanHuguesRobert/cogentia/blob/main/research/ia_pour_tous_ia_pour_chacun.md"
+---
+
+# Espérer sans promettre
+
+## Minimiser la casse pendant la transition vers une démocratie augmentée
+
+## Statut et objet
+
+Ce document ne prédit pas l'avènement nécessaire d'une démocratie augmentée par l'intelligence artificielle. Il expose une possibilité, les conditions qui pourraient la rendre praticable, les bifurcations qui pourraient la faire échouer et les raisons d'agir avant que l'issue soit connue.
+
+Il prolonge **Democratic AI Safety** et **DHITL — Democratic Humans In The Loop**. Ces travaux soutiennent que la sécurité de l'intelligence artificielle ne dépend pas seulement du comportement des modèles. Elle dépend aussi de la propriété des infrastructures, de la distribution du compute, de la souveraineté cognitive des personnes, de la traçabilité des actes et de l'autorité politique qui décide des usages permis.
+
+La question de ce document est temporelle :
+
+> **Que faire pendant la transition, lorsque les capacités augmentent rapidement mais que les institutions capables de les gouverner n'existent pas encore complètement ?**
+
+La réponse proposée n'est pas une promesse de victoire. Elle consiste à construire assez tôt des capacités personnelles et collectives qui augmentent la probabilité d'une issue démocratique et réduisent les souffrances évitables en chemin.
+
+---
+
+## 1. Une espérance sans garantie
+
+La modernité a eu de bonnes raisons de cesser de croire à un progrès automatique. La science, la technique, la croissance et l'administration ne conduisent pas mécaniquement à davantage de liberté, de justice ou de dignité. Elles peuvent aussi concentrer le pouvoir, rendre les dépendances plus opaques et donner aux acteurs déjà dominants des moyens d'action disproportionnés.
+
+Mais le rejet de la croyance naïve au progrès peut produire une erreur symétrique : puisque le progrès n'est pas garanti, rien ne mériterait plus d'être tenté. Le scepticisme devient alors cynisme ; le cynisme devient nihilisme ; le nihilisme transforme l'impuissance en posture de lucidité.
+
+Le possibilisme refuse ces deux simplifications :
+
+> **Le progrès n'est ni certain ni impossible. Il devient une possibilité qu'il faut rendre praticable.**
+
+L'espoir n'est donc pas la conviction que tout finira bien. Il est la perception qu'il existe encore au moins un chemin praticable, suffisamment crédible pour justifier l'action, suffisamment ouvert pour rester contestable, et suffisamment traçable pour que ses erreurs puissent être corrigées.
+
+Cette espérance est une ressource politique. Elle ne dispense pas de regarder les risques ; elle évite que leur contemplation se transforme en résignation.
+
+---
+
+## 2. Deux pathologies de l'incapacité
+
+Deux pathologies paraissent particulièrement graves dans la période actuelle : le cynisme virant au nihilisme et la solitude subie.
+
+Elles peuvent se renforcer mutuellement :
+
+```text
+isolement
+→ sentiment d'impuissance
+→ retrait du monde commun
+→ cynisme protecteur
+→ incapacité à faire confiance
+→ isolement accru
+```
+
+La réponse ne peut pas être uniquement psychologique, morale ou technique. Elle doit rendre à chacun une capacité effective : comprendre, explorer, créer, demander de l'aide, contribuer à une œuvre, rejoindre une communauté, contester un acte et constater que son action produit parfois un effet réel.
+
+Une intelligence artificielle personnelle peut réduire certaines formes d'isolement cognitif. Elle ne doit pas pour autant devenir le substitut commode d'une humanité absente. Sa fonction souhaitable est d'aider une personne à retrouver sa capacité d'entrer en relation, de participer et de construire avec d'autres.
+
+---
+
+## 3. Du désir de continuation au jumeau numérique
+
+Le désir de continuation est ancien. Il peut prendre la forme d'un désir d'immortalité, de transmission d'une œuvre, de préservation d'une mémoire, de fidélité à des valeurs ou de continuité d'une intention après la disparition physique.
+
+Les intelligences artificielles rendent progressivement possible la construction de représentations opérationnelles d'une personne : Corpus, Cogentia, Cogentigram, agents personnels et jumeaux numériques. Ces représentations restent approximatives. La carte n'est pas le territoire ; le jumeau n'est pas la personne ; la continuation n'est pas l'identité totale.
+
+Pour être légitime, un jumeau numérique doit rechercher la fidélité aux intérêts, valeurs, intentions et limites de son principal. Il doit pouvoir exprimer son incertitude, être corrigé, révoqué, porté ailleurs et distingué de la personne qu'il représente.
+
+Le désir de continuation produit ainsi une demande probable pour des jumeaux numériques. Il ne détermine pas qui les contrôlera.
+
+---
+
+## 4. La bifurcation institutionnelle
+
+La même capacité technique ouvre au moins deux trajectoires.
+
+```text
+désir de continuation
+→ demande de jumeaux numériques
+→ bifurcation institutionnelle
+
+jumeaux captifs
+→ dépendance aux plateformes
+→ concentration cognitive
+→ oligarchie
+
+jumeaux souverains
+→ IA pour chacun
+→ coopération entre personnes augmentées
+→ IA pour tous
+→ fédération démocratique
+```
+
+### 4.1. Jumeaux captifs
+
+Dans la première trajectoire, les données, modèles, mémoires, identités et capacités d'action sont contrôlés par quelques plateformes. La continuation devient un service conditionnel, révocable par le fournisseur, orienté par ses intérêts économiques et accessible selon la richesse du client.
+
+Cette trajectoire peut produire une féodalité numérique : immortalité par abonnement, agents personnels captifs, mémoires appropriées, dépendance à un fournisseur et capacité de persuasion concentrée.
+
+### 4.2. Jumeaux souverains
+
+Dans la seconde trajectoire, chaque personne conserve une autorité effective sur son Corpus, son jumeau, ses mandats, ses données et les ressources de compute nécessaires à leur fonctionnement. Les agents personnels peuvent coopérer, mais ils ne multiplient pas la voix politique de leur principal et ne deviennent pas eux-mêmes souverains.
+
+La coordination entre personnes ainsi augmentées appelle alors des protocoles communs, des espaces de délibération, des règles d'interopérabilité, des traces et des institutions fédérées. **IA pour chacun** peut rejoindre **IA pour tous**.
+
+Cette issue n'est pas mécanique. Elle dépend de conditions politiques et techniques : portabilité, propriété ou contrôle effectif, mandats explicites, révocabilité, ressources accessibles, protocoles ouverts, égalité politique des vivants et capacité de contester les actes engageants.
+
+---
+
+## 5. La transition comme objet de sécurité
+
+L'issue de long terme peut être démocratique ; la transition ne le sera pas spontanément.
+
+Durant cette période, les capacités des agents peuvent croître plus vite que les protections institutionnelles. Les personnes et petites communautés peuvent devenir dépendantes avant de disposer d'alternatives. Les emplois et revenus peuvent être détruits avant que de nouveaux droits sur le temps, le compute et la contribution soient institués. Les systèmes de mémoire peuvent être capturés avant que leur portabilité soit garantie. La transparence peut progresser moins vite que les moyens d'opacité et de manipulation.
+
+Il y aura probablement de la casse, des erreurs, des dépendances et des souffrances inutiles. La finalité réaliste n'est pas de promettre qu'elles disparaîtront. Elle est de les minimiser, de préserver les voies de correction et d'éviter les irréversibilités les plus graves.
+
+La sécurité de la transition repose notamment sur :
+
+- des agents sous mandat humain explicite ;
+- une séparation entre lire, proposer, publier et agir ;
+- des actes engageants traçables et contestables ;
+- des ressources personnelles et collectives de compute ;
+- des alternatives aux plateformes captives ;
+- des continuations permettant de suspendre et reprendre sans perdre l'intention ;
+- une fédération progressive des communautés plutôt qu'une centralisation prématurée ;
+- la publicité des erreurs, limites et modes dégradés ;
+- une protection réelle des personnes qui révèlent les abus.
+
+---
+
+## 6. Du travail imposé au travail à une œuvre
+
+L'intelligence artificielle ne doit pas être évaluée seulement par le nombre d'emplois qu'elle conserve ou détruit. La catégorie d'emploi mélange des réalités opposées.
+
+Le **travail à une œuvre** permet à une personne de donner forme à une intention, d'explorer une partie du Possible qui la motive, de contribuer à quelque chose qu'elle reconnaît comme sien ou comme commun. Il peut être rémunéré ou non, salarié ou indépendant.
+
+Le **travail imposé** capte le temps, l'attention et l'énergie au profit d'une finalité extérieure que la personne ne peut réellement discuter. Le salariat en fournit une forme fréquente, mais non exclusive. Une activité formellement indépendante peut également devenir extractive et prédatrice.
+
+Le critère pertinent est l'effet de l'activité sur les capacités de la personne : augmente-t-elle ou réduit-elle son pouvoir de comprendre, choisir, expérimenter, créer, contribuer et se retirer ?
+
+Le progrès devrait donc produire un **dividende de capacité** :
+
+```text
+temps souverain
++ sécurité matérielle
++ compute disponible
++ accès aux savoirs
++ agents personnels fidèles
++ liberté d'exploration
++ capacité de contribuer à une œuvre
+```
+
+L'objectif n'est pas de supprimer toute contrainte ou tout travail nécessaire. Il est de partager équitablement les contraintes et de rendre à chacun davantage de temps et de moyens pour les œuvres qu'il choisit.
+
+---
+
+## 7. Une constitution par l'expérimentation
+
+Il n'existe pas encore de réponse structurelle complète à la constitution initiale d'un système DHITL. Qui définit le premier demos ? Qui adopte les premières règles ? Comment une initiative fondatrice transfère-t-elle son autorité à une communauté ?
+
+La stratégie provisoire est possibiliste : commencer là où un mandat réel peut être obtenu, rendre l'expérience vérifiable, laisser l'adhésion volontaire produire l'extension, puis fédérer les expériences qui le souhaitent.
+
+```text
+ne pas attendre la constitution idéale
+→ agir dans les périmètres où un mandat réel existe
+→ produire des résultats traçables
+→ permettre l'adhésion volontaire
+→ fédérer progressivement les expériences concluantes
+```
+
+Les premiers terrains envisagés à Corte couvrent plusieurs échelles : une personne, la copropriété du 1 cours Paoli, la commune de Corte, l'Université de Corse, l'association C.O.R.S.I.C.A., le fonds de dotation Barons Mariani et le fonds de dotation Les Amis de Malou.
+
+La formule populaire est : **« Qui m'aime me suive. »**
+
+Elle ne doit pas signifier : « le fondateur décide pour tous ». Elle signifie :
+
+> **Je commence là où je peux agir légitimement ; je publie les mandats, les méthodes, les erreurs et les résultats ; personne n'est obligé de me suivre ; chacun peut contester, reprendre, adapter, quitter ou fédérer.**
+
+Les résultats ne parlent d'eux-mêmes que si l'état initial, les actes, les ressources, les objections, les corrections et les capacités gagnées restent lisibles.
+
+---
+
+## 8. Transparence, trace et recours
+
+La transparence ne doit pas dépendre exclusivement de contrôleurs habilités dont l'indépendance peut être achetée ou capturée. Le citoyen doit pouvoir accéder aux traces publiques, vérifier les actes, produire des analyses, formuler des objections et, autant que possible, ester en justice.
+
+La non-divulgation doit rester une exception motivée, proportionnée et bornée dans le temps. L'acte de soustraire une information à la publicité devrait lui-même laisser une trace : objet, responsable, fondement, durée, effets et voie de contestation.
+
+L'OSINT peut reconstruire des chaînes probables de responsabilité à partir de données publiques. Il ne doit pas transformer une inférence en condamnation automatique. Une infrastructure saine distingue :
+
+```text
+fait vérifié
+indice
+inférence
+hypothèse de responsabilité
+contradiction reçue
+fait réfuté
+qualification juridique éventuelle
+```
+
+Deux formules résument la fonction politique de cette infrastructure :
+
+> **Sans trace, impunité.**
+
+> **Sans recours, la trace reste contemplative.**
+
+---
+
+## 9. Ce qui pourrait faire échouer cette espérance
+
+Cette trajectoire serait affaiblie ou réfutée si :
+
+- la majorité des personnes préférait durablement la commodité de jumeaux captifs à leur souveraineté ;
+- la portabilité et l'interopérabilité se révélaient impraticables à un coût accessible ;
+- la concentration du compute rendait les alternatives démocratiques insignifiantes ;
+- les agents personnels augmentaient la manipulation ou l'isolement davantage qu'ils n'augmentent la capacité ;
+- les communautés expérimentales reproduisaient les mêmes captures que les plateformes dominantes ;
+- les dispositifs de trace devenaient principalement des instruments de surveillance ;
+- la participation démocratique ne pouvait suivre la vitesse des changements techniques ;
+- la promesse d'un dividende de capacité ne produisait aucun gain mesurable de temps, de ressources ou d'autonomie.
+
+Ces risques ne justifient pas l'inaction. Ils indiquent ce qu'il faut mesurer, rendre contestable et pouvoir abandonner.
+
+---
+
+## 10. Programme d'action
+
+La transition appelle moins une nouvelle proclamation qu'une série d'expériences reliées :
+
+1. stabiliser la doctrine **IA pour tous, IA pour chacun** ;
+2. documenter les pilotes personnels, associatifs, territoriaux et institutionnels de Corte ;
+3. construire COP comme protocole d'orchestration durable et Archia comme mémoire longue ;
+4. rendre les actes engageants traçables, imputables et contestables ;
+5. consolider un dispositif complet de protection des lanceurs d'alerte ;
+6. mesurer les gains de capacité : temps, compute, accès, compréhension, possibilité d'agir et de contribuer ;
+7. conserver les échecs comme informations permettant une continuation plus fidèle.
+
+Le but n'est pas de vendre la peau de l'ours avant de l'avoir tué. Il est de ne pas laisser le seul chemin praticable être celui que les acteurs les plus puissants auront construit pour eux-mêmes.
+
+---
+
+## Conclusion
+
+Nous ne savons pas si le progrès l'emportera. Nous savons seulement qu'une issue démocratique demeure possible si les personnes conservent le contrôle de leurs capacités cognitives, si les communautés disposent d'infrastructures communes, si les actes des puissants deviennent vérifiables et si les erreurs restent corrigibles.
+
+L'espoir commence lorsqu'une possibilité devient praticable, partageable et transmissible.
+
+> **Le contraire du nihilisme n'est pas la croyance aveugle au progrès. C'est la capacité retrouvée de produire ensemble des améliorations réelles, même fragiles, et d'en conserver la trace.**
+
+---
+
+## Continuation
+
+Ce document doit être repris lorsque :
+
+- les premiers pilotes DHITL disposent de résultats observables ;
+- un protocole de transfert de l'autorité fondatrice vers une communauté est expérimenté ;
+- des indicateurs du dividende de capacité sont testés ;
+- le contrôle ou la portabilité d'un jumeau numérique fait l'objet d'un précédent juridique ou technique significatif ;
+- une expérimentation montre que l'une des deux trajectoires décrites ici doit être corrigée ou complétée.
+
+La prochaine version ne devrait pas ajouter de force rhétorique. Elle devrait ajouter une preuve, une objection sérieuse, un résultat expérimental ou une meilleure condition de falsification.
+


### PR DESCRIPTION
## Objet

Cette PR transforme notre conversation de consolidation en deux documents sources durables :

- `research/transition_possibiliste_vers_une_democratie_augmentee.md`
- `research/protection_des_lanceurs_d_alerte.md`

## Intention

Le premier texte formalise un possibilisme politique : l’issue démocratique est un espoir conditionnel, non une promesse mécanique. Il définit la transition comme un objet de sûreté, distingue le travail à une œuvre du travail imposé, introduit le dividende de capacité et documente la stratégie des expérimentations de proximité.

Le second reconstruit la doctrine discutée sur les lanceurs d’alerte : continuité de capacité, publicité par défaut, non-divulgation exceptionnelle et bornée, enquête OSINT prudente et possibilité effective de recours citoyen.

## Prudence éditoriale

- Les propositions normatives sont distinguées du droit positif.
- La note sur les lanceurs d’alerte reste explicitement en version de travail jusqu’à une recherche juridique et une revue praticienne.
- Aucun document souverain existant n’est modifié par cette PR.

## Vérifications

- cohérence des métadonnées et URL canoniques ;
- structure Markdown et blocs YAML relus ;
- absence de fichier homonyme repérée avant création ;
- pas de test logiciel applicable à ces documents.